### PR TITLE
Cleanup Bits functions

### DIFF
--- a/Bits.fs
+++ b/Bits.fs
@@ -3,22 +3,11 @@ module ISA.RISCV.Utils.Bits
 type System.Int64 with
     member x.bitSlice endBit startBit = // get Bit slice from range
         (x >>> startBit) &&& ~~~(-1L <<< (endBit - startBit + 1))
-    member x.signExtend n = // Sign extend bits for x64
-        let bitOffset = 64 - n
-        (x <<< bitOffset) >>> bitOffset
-    member x.align = // get x64 mask with all `1` bits
-        x &&& (-1L)
-    member x.flip i = // change bit
-        (x ^^^ (1L <<< i))
     member x.isSet i = // test if bit set at a specified position
         x &&& (1L <<< i) <> 0L
-    member x.rotateLeft r =
-        (x <<< r) ||| (x >>> (32 - r))
-    member x.rotateRight r =
-        (x >>> r) ||| (x <<< (32 - r))
 
-    (* bit coersion methods *)
-    member x.toHex = sprintf "0x%x" x   // to hexadecimal
+    (* bit coercion methods *)
+    member x.toHex = $"0x%x{x}"   // to hexadecimal
     member x.toBin = // to binary string
         System.Convert.ToString(x, 2).PadLeft(64, '0')
     member x.toResizeArray = // to Resizable array of positions set to 1
@@ -29,21 +18,12 @@ type System.Int64 with
     member x.toArray = // to array of positions set to 1
         let res = x.toResizeArray
         res.ToArray()
-    member x.toList = // to list of positions set to 1
-        let res = x.toResizeArray
-        Array.toList (res.ToArray())
-    member x.toSeq = // to seq of positions set to 1
-        let res = x.toResizeArray
-        Array.toSeq (res.ToArray())
 
     (* bit print methods *)
-    member x.print = printf "%A" x
+    member x.print = printf $"%A{x}"
     member x.display = // helper to show bits
-        x.toArray |> Seq.iter(fun i -> printf "%A " i)
+        x.toArray |> Seq.iter(fun i -> printf $"%A{i} ")
 
-    (* misc methods *)
-    member x.abs = // fast math.abs
-        (x ^^^ (x >>> 31)) - (x >>> 31)
 
 type System.Int32 with
     member x.bitSlice endBit startBit = // get Bit slice from range
@@ -51,8 +31,6 @@ type System.Int32 with
     member x.signExtend n = // Sign extend bits for x32
         let bitOffset = 32 - n
         (x <<< bitOffset) >>> bitOffset
-    member x.align = // get x32 mask with all `1` bits
-        x &&& (-1)
 
 let combineBytes (x : byte array) : int64 =
     let xz = Array.zip [|0..x.Length-1|] x


### PR DESCRIPTION
# Description

- Clean up unused Bits functions in `Bits.fs`. New functions, more over are potentially buggy.
-  For `Bits.fs` refactored `print` functions.

Related to #13 