### PR TITLE
Feat: add  RV32C/RV64C 'C' compressed extension 

### DIFF
--- a/Arch.fs
+++ b/Arch.fs
@@ -21,6 +21,14 @@ type Architecture =
     | RV64ia
     | RV32ima
     | RV64ima
+    | RV32ic
+    | RV64ic
+    | RV32imc
+    | RV64imc
+    | RV32iac
+    | RV64iac
+    | RV32imac
+    | RV64imac
     static member fromString (x : string) =
         match x with
         | "rv32i"  -> Some(RV32i)
@@ -31,12 +39,38 @@ type Architecture =
         | "rv64ia" -> Some(RV64ia)
         | "rv32ima" -> Some(RV32ima)
         | "rv64ima" -> Some(RV64ima)
+        | "rv32ic"  -> Some(RV32ic)
+        | "rv64ic"  -> Some(RV64ic)
+        | "rv32imc" -> Some(RV32imc)
+        | "rv64imc" -> Some(RV64imc)
+        | "rv32iac" -> Some(RV32iac)
+        | "rv64iac" -> Some(RV64iac)
+        | "rv32imac" -> Some(RV32imac)
+        | "rv64imac" -> Some(RV64imac)
         | _ -> None
 
     member x.archBits = // Get architecture bits
         match x with
-        | RV32 | RV32i | RV32im | RV32ia | RV32ima -> RV32
-        | RV64 | RV64i | RV64im | RV64ia | RV64ima -> RV64
+        | RV32 | RV32i | RV32im | RV32ia | RV32ima
+        | RV32ic | RV32imc | RV32iac | RV32imac -> RV32
+        | _ -> RV64
+
+    // Standard-extension predicates (used for decode gating in Decoder.fs)
+    member x.hasM =
+        match x with
+        | RV32im | RV32imc | RV32ima | RV32imac
+        | RV64im | RV64imc | RV64ima | RV64imac -> true
+        | _ -> false
+    member x.hasA =
+        match x with
+        | RV32ia | RV32iac | RV32ima | RV32imac
+        | RV64ia | RV64iac | RV64ima | RV64imac -> true
+        | _ -> false
+    member x.hasC =
+        match x with
+        | RV32ic | RV32imc | RV32iac | RV32imac
+        | RV64ic | RV64imc | RV64iac | RV64imac -> true
+        | _ -> false
 
 type TrapErrors =
     | InstructionFetch of MachineInt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,207 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+`riscv-fs` is a formal RISC-V ISA simulator written in F#: it decodes and executes
+RISC-V instructions, loads ELF files, and runs from a CLI.
+
+## [0.6.0] - 2026-06-02
+
+The **"C" (Compressed)** extension release. ([#20])
+
+### Added
+
+- **RV32C / RV64C "C" (Compressed) Standard Extension** — full integer subset, decode
+  (`DecodeC.fs`) and execute (`ExecuteC.fs`) for every 16-bit instruction across all three
+  quadrants: `C.ADDI4SPN`, `C.LW`/`C.SW`, `C.LD`/`C.SD` (RV64), `C.ADDI`/`C.NOP`,
+  `C.JAL` (RV32), `C.ADDIW` (RV64), `C.LI`, `C.LUI`, `C.ADDI16SP`,
+  `C.SRLI`/`C.SRAI`/`C.ANDI`, `C.SUB`/`C.XOR`/`C.OR`/`C.AND`, `C.SUBW`/`C.ADDW` (RV64),
+  `C.J`, `C.BEQZ`/`C.BNEZ`, `C.SLLI`, `C.LWSP`/`C.LDSP` (RV64), `C.JR`/`C.JALR`,
+  `C.MV`, `C.ADD`, `C.EBREAK`, `C.SWSP`/`C.SDSP` (RV64).
+- Eight new architecture variants: `rv32ic`, `rv32imc`, `rv32iac`, `rv32imac`,
+  `rv64ic`, `rv64imc`, `rv64iac`, `rv64imac` (`Arch.fromString`, `hasC` predicate).
+- Automatic instruction-length detection from `inst[1:0]`, derived in `Decoder.Decode` and
+  baked into the returned executor, so compressed (2-byte) and standard (4-byte)
+  instructions advance the PC and link addresses correctly through any decode→execute path.
+- `IALIGN = 2` when the C extension is present: 2-byte-aligned jump/branch targets are
+  legal and no longer trap.
+- HINT handling per the C-extension spec: `C.LUI`/`C.LI`/`C.MV`/`C.ADD`/`C.ADDI`/`C.SLLI`
+  with `rd = x0` (and shamt-0 shifts) execute as no-ops instead of trapping.
+- New test suites `Tests/rvc/c.fs` and `Tests/unit/branch.fs`; the project now reaches
+  **100% line coverage and 100% branch coverage**.
+
+### Changed
+
+- `Decoder.Decode` now owns `InstrLen` (removing the hidden dependency on externally-set
+  machine state for correct compressed-instruction PC/link advancement).
+- CLI `--arch` help lists all 16 supported architectures and marks `-A/--arch` as
+  **required** (it previously advertised a non-existent `rv32i` default).
+- `MachineState.storeMemory*` refactored into a single recursive `storeBytes` helper;
+  CLI argument handling uses `Array.skip` instead of array slicing (clearer and
+  branch-complete).
+
+### Fixed
+
+- `C.LUI` with `rd = x0, nzimm ≠ 0` is decoded as a HINT (no-op) instead of an illegal
+  instruction — direct RISC-V C-extension conformance fix.
+- `C.ADDIW rd, 0` correctly behaves as `sext.w rd` (the `imm = 0` encoding is valid, not
+  reserved); added an explicit regression test.
+- Removed a dead defensive branch in the `Program.fs` error handler.
+
+## [0.5.0] - 2026-06-01
+
+Robustness, conformance, and tooling release: .NET 10, an RV32 shift fix, and a full
+audit pass. ([#17], [#18], [#19])
+
+### Added
+
+- Run-loop **step limit**: a non-terminating program (e.g. a backward self-branch) aborts
+  with a `StepLimit` trap instead of hanging. ([#19])
+- ELF loader now loads **all `PT_LOAD` segments** (code, data, zero-filled `.bss`) for both
+  32- and 64-bit ELF. ([#19])
+- LR/SC **reservation semantics** (so `SC` can fail) and misaligned-atomic traps. ([#19])
+- Verbose **instruction trace** (`-v`) and dynamic CLI version/author (read from assembly
+  metadata, dynamic year). ([#19])
+- **Code coverage in CI** (Codecov) and expanded unit/integration tests for CLI, decoding,
+  execution, atomics, and ELF handling. ([#19])
+
+### Changed
+
+- Upgraded to **.NET 10** (from .NET 8). ([#17])
+- ELF loading and the run cycle are wrapped in exception handling — malformed input is
+  reported instead of crashing. ([#19])
+- Project version is single-sourced from `<Version>` in the `.fsproj` and read via assembly
+  metadata. ([#19])
+- `setRegister` is now immutable (copies the register array, preserving prior states). ([#19])
+- CI migrated to GitHub Actions. ([#19])
+
+### Fixed
+
+- RV32 `SLL`/`SRL`/`SRA` now mask the shift amount to `rs2[4:0]`; shifts ≥ 32 previously
+  produced wrong results. ([#18])
+- RV64 `IMA` opcode conformance: `.D` atomics funct5/`rs2` decoding, RV64 6-bit shamt
+  (`inst[25:20]`), and `DIVUW`/`REMUW` operating on the low 32 bits (unsigned). ([#19])
+- 32-bit `AMO.W` uses the correct `rs2` width. ([#19])
+- RV32 `DIV`/`REM` overflow edge case. ([#19])
+- CLI long-key value argument-index handling. ([#19])
+- Hygiene: module rename, typo fixes, `StartsWith` usage, and documentation comments. ([#19])
+
+## [0.4.1] - 2024-01-27
+
+Maintenance release. ([#12], [#14], [#15])
+
+### Added
+
+- Continuous Integration pipeline. ([#15])
+
+### Changed
+
+- Updated to **.NET 8** and **F# 5**. ([#12])
+- Cleaned up `Bits.fs` helper functions. ([#14])
+
+### Fixed
+
+- `ExecuteI` instruction-execution fixes. ([#15])
+
+## [0.4.0] - 2020-06-11
+
+The **"A" (Atomic)** extension release. ([#10], [#11])
+
+### Added
+
+- **RV32A / RV64A "A" (Atomic Memory Operations) Standard Extension**: `LR`/`SC` and the
+  AMO operations (`SWAP`, `ADD`, `XOR`, `AND`, `OR`, `MIN`, `MAX`, `MINU`, `MAXU`) for both
+  `.W` and `.D`. ([#10])
+- `MachineState` store-to-memory methods. ([#10])
+- Comprehensive AMO test suite with assembler sources. ([#11])
+
+### Changed
+
+- `SB`/`SH`/`SW`/`SD` store instructions reworked to use the `MachineState` store-to-memory
+  methods. ([#10])
+- CLI options reworked. ([#10])
+
+## [0.3.0] - 2019-12-09
+
+The **"M" (Multiply/Divide)** extension release. ([#8], [#9])
+
+### Added
+
+- **RV32M / RV64M "M" (Integer Multiplication and Division) Standard Extension**:
+  `MUL`, `MULH`, `MULHSU`, `MULHU`, `DIV`, `DIVU`, `REM`, `REMU` (and the 64-bit `*W`
+  variants). ([#8])
+- M-extension test suite (32- and 64-bit) with assembler sources. ([#9])
+
+### Fixed
+
+- `MULHU` algorithm. ([#8])
+
+## [0.2.0] - 2019-11-09
+
+The **RV64I** base release. ([#6], [#7])
+
+### Added
+
+- **RV64I** base integer instruction set: 64-bit decoder and executor, the `*W`
+  word instructions, and 64-bit `shamt` handling. ([#6])
+- RV64I test suite — ALU, ALU-immediate, branches, jumps, upper-immediate, system, and
+  memory tests. ([#7])
+
+### Changed
+
+- Instructions widened to a 32-bit field representation and all dependencies updated. ([#6])
+- Decoder logic reworked to support both RV32 and RV64. ([#6])
+
+## [0.1.0] - 2019-10-26
+
+Initial release: the **RV32I** base integer ISA. ([#1], [#2], [#3], [#4], [#5])
+
+### Added
+
+- **RV32I** base integer instruction set — decoder and executor for `LUI`, `AUIPC`, `JAL`,
+  `JALR`, the branch family, loads/stores, the ALU and ALU-immediate families, `FENCE`,
+  `ECALL`, and `EBREAK`.
+- ELF file reading and a CLI with verbosity output.
+- Comprehensive RV32I test suite (ALU, ALU-immediate, branches, jumps, upper-immediate,
+  memory, system) with assembler test sources. ([#4])
+- TravisCI integration. ([#1])
+- Project documentation: README, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and issue
+  templates. ([#2], [#5])
+
+### Changed
+
+- Opcode representation reworked for the decode flow. ([#3])
+
+### Fixed
+
+- Branch instructions, `BLTU`/`BGEU`, `SRL`, `SRLI`/`SLTIU`, and `JALR` execution.
+
+[0.6.0]: https://github.com/mrLSD/riscv-fs/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/mrLSD/riscv-fs/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/mrLSD/riscv-fs/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/mrLSD/riscv-fs/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/mrLSD/riscv-fs/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/mrLSD/riscv-fs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/mrLSD/riscv-fs/releases/tag/v0.1.0
+
+[#1]: https://github.com/mrLSD/riscv-fs/pull/1
+[#2]: https://github.com/mrLSD/riscv-fs/pull/2
+[#3]: https://github.com/mrLSD/riscv-fs/pull/3
+[#4]: https://github.com/mrLSD/riscv-fs/pull/4
+[#5]: https://github.com/mrLSD/riscv-fs/pull/5
+[#6]: https://github.com/mrLSD/riscv-fs/pull/6
+[#7]: https://github.com/mrLSD/riscv-fs/pull/7
+[#8]: https://github.com/mrLSD/riscv-fs/pull/8
+[#9]: https://github.com/mrLSD/riscv-fs/pull/9
+[#10]: https://github.com/mrLSD/riscv-fs/pull/10
+[#11]: https://github.com/mrLSD/riscv-fs/pull/11
+[#12]: https://github.com/mrLSD/riscv-fs/pull/12
+[#14]: https://github.com/mrLSD/riscv-fs/pull/14
+[#15]: https://github.com/mrLSD/riscv-fs/pull/15
+[#17]: https://github.com/mrLSD/riscv-fs/pull/17
+[#18]: https://github.com/mrLSD/riscv-fs/pull/18
+[#19]: https://github.com/mrLSD/riscv-fs/pull/19
+[#20]: https://github.com/mrLSD/riscv-fs/pull/20

--- a/CLI.fs
+++ b/CLI.fs
@@ -142,7 +142,7 @@ let rec fetchArgs (argv : string[]) (opts : CliOptions) (cfg : AppConfig) =
 
         match cfgRes with
         | Result(res) when opts.Multiple && argv.Length - resIndex > 0 ->
-            let cfgRes = fetchArgs argv.[resIndex..] opts res
+            let cfgRes = fetchArgs (Array.skip resIndex argv) opts res
             // If NotFound for that branch loop -
             // redeclare to Result type
             let resValue = match cfgRes with
@@ -150,11 +150,11 @@ let rec fetchArgs (argv : string[]) (opts : CliOptions) (cfg : AppConfig) =
                            | _ -> cfgRes
             resValue
         | NotFound(res) when argv.Length > 0 ->
-            let (cfgRes, changedArgs) = fetchArgs argv.[1..] opts res
+            let (cfgRes, changedArgs) = fetchArgs (Array.skip 1 argv) opts res
             (cfgRes, Array.append [|arg|] changedArgs)
         | _ ->
             if argv.Length - resIndex > 0 then
-                (cfgRes, argv.[resIndex..])
+                (cfgRes, Array.skip resIndex argv)
             else
                 (cfgRes, [||])
 
@@ -164,7 +164,7 @@ let rec parseCli (argv : string[]) (opts : CliOptions[]) (cfg : AppConfig) =
         Success(cfg)
     else
         let opt = opts.[0]
-        let opts = if opts.Length > 1 then opts.[1..] else [||]
+        let opts = if opts.Length > 1 then Array.skip 1 opts else [||]
         let (resCfg, newArgv) = fetchArgs argv opt cfg
         match resCfg with
         | Error ->

--- a/CLI.fs
+++ b/CLI.fs
@@ -184,7 +184,7 @@ let rec InitCLI =
             Key =  Some("A");
             LongKey = Some("arch");
             Value = Some("ARCH")
-            HelpMessage = "RISC-V architecture. Available: rv32i, rv32im, rv32ia, rv32ima, rv64i, rv64im, rv64ia, rv64ima. Default: rv32i"
+            HelpMessage = "RISC-V architecture (required). Available: rv32i, rv32im, rv32ia, rv32ima, rv32ic, rv32imc, rv32iac, rv32imac, rv64i, rv64im, rv64ia, rv64ima, rv64ic, rv64imc, rv64iac, rv64imac"
             Handler =
                 fun arg cfg ->
                     { cfg with

--- a/DecodeC.fs
+++ b/DecodeC.fs
@@ -1,0 +1,180 @@
+module ISA.RISCV.Decode.C
+
+open System
+open ISA.RISCV.Utils.Bits
+open ISA.RISCV.Arch
+open ISA.RISCV.MachineState
+
+//================================================================
+// 'C'  (Compressed 16-bit instructions 'C' Standard Extension)
+// Each compressed instruction is the short form of a base instruction;
+// Decode expands the operands so Execute can reuse the base semantics.
+// FP-compressed (C.FLD/C.FSD/C.FLW/C.FSW, *SP) belong to Zcf/Zcd and
+// require F/D — on an arch without F/D they are reserved and decode to None.
+type InstructionC =
+    | C_ADDI4SPN of {| rd: Register; imm: InstrField |}
+    | C_LW       of {| rd: Register; rs1: Register; imm: InstrField |}
+    | C_LD       of {| rd: Register; rs1: Register; imm: InstrField |}
+    | C_SW       of {| rs1: Register; rs2: Register; imm: InstrField |}
+    | C_SD       of {| rs1: Register; rs2: Register; imm: InstrField |}
+    | C_ADDI     of {| rd: Register; imm: InstrField |}
+    | C_ADDIW    of {| rd: Register; imm: InstrField |}
+    | C_LI       of {| rd: Register; imm: InstrField |}
+    | C_LUI      of {| rd: Register; imm: InstrField |}
+    | C_ADDI16SP of {| imm: InstrField |}
+    | C_SRLI     of {| rd: Register; shamt: InstrField |}
+    | C_SRAI     of {| rd: Register; shamt: InstrField |}
+    | C_ANDI     of {| rd: Register; imm: InstrField |}
+    | C_SUB      of {| rd: Register; rs2: Register |}
+    | C_XOR      of {| rd: Register; rs2: Register |}
+    | C_OR       of {| rd: Register; rs2: Register |}
+    | C_AND      of {| rd: Register; rs2: Register |}
+    | C_SUBW     of {| rd: Register; rs2: Register |}
+    | C_ADDW     of {| rd: Register; rs2: Register |}
+    | C_J        of {| imm: InstrField |}
+    | C_JAL      of {| imm: InstrField |}
+    | C_BEQZ     of {| rs1: Register; imm: InstrField |}
+    | C_BNEZ     of {| rs1: Register; imm: InstrField |}
+    | C_SLLI     of {| rd: Register; shamt: InstrField |}
+    | C_LWSP     of {| rd: Register; imm: InstrField |}
+    | C_LDSP     of {| rd: Register; imm: InstrField |}
+    | C_JR       of {| rs1: Register |}
+    | C_JALR     of {| rs1: Register |}
+    | C_MV       of {| rd: Register; rs2: Register |}
+    | C_ADD      of {| rd: Register; rs2: Register |}
+    | C_EBREAK
+    | C_SWSP     of {| rs2: Register; imm: InstrField |}
+    | C_SDSP     of {| rs2: Register; imm: InstrField |}
+    | None // Instruction not found
+
+// CJ-format immediate (C.J / C.JAL), sign-extended 12-bit
+let private cjImm (instr : InstrField) : InstrField =
+    ((instr.bitSlice 12 12 <<< 11) ||| (instr.bitSlice  8  8 <<< 10) ||| (instr.bitSlice 10  9 <<< 8)
+     ||| (instr.bitSlice  6  6 <<< 7) ||| (instr.bitSlice  7  7 <<< 6) ||| (instr.bitSlice  2  2 <<< 5)
+     ||| (instr.bitSlice 11 11 <<< 4) ||| (instr.bitSlice  5  3 <<< 1)).signExtend 12
+
+// CB-format immediate (C.BEQZ / C.BNEZ), sign-extended 9-bit
+let private cbImm (instr : InstrField) : InstrField =
+    ((instr.bitSlice 12 12 <<< 8) ||| (instr.bitSlice 6 5 <<< 6) ||| (instr.bitSlice 2 2 <<< 5)
+     ||| (instr.bitSlice 11 10 <<< 3) ||| (instr.bitSlice 4 3 <<< 1)).signExtend 9
+
+/// Decode 'C' (compressed) instructions
+let Decode (mstate : MachineState) (instr : InstrField) : InstructionC =
+    let rv64   = mstate.Arch.archBits = RV64
+    let op     = instr.bitSlice 1 0
+    let funct3 = instr.bitSlice 15 13
+    // 3-bit compressed register operands map to x8..x15
+    let rdc    = (instr.bitSlice 4 2) + 8     // rd'/rs2' field at [4:2]
+    let rs1c   = (instr.bitSlice 9 7) + 8     // rs1'/rd'  field at [9:7]
+    // wide register operands
+    let rdw    = instr.bitSlice 11 7
+    let rs2w   = instr.bitSlice 6 2
+    // shamt for CI/CB shifts (6-bit; RV32 requires bit 5 = 0)
+    let shamt  = (instr.bitSlice 12 12 <<< 5) ||| instr.bitSlice 6 2
+    let shamtOk = rv64 || (instr.bitSlice 12 12) = 0
+    let imm6   = ((instr.bitSlice 12 12 <<< 5) ||| instr.bitSlice 6 2).signExtend 6
+
+    match op with
+    // ---- Quadrant 0 ----
+    | 0b00 ->
+        match funct3 with
+        | 0b000 ->   // C.ADDI4SPN -> addi rd', x2, nzuimm
+            let imm = (instr.bitSlice 10 7 <<< 6) ||| (instr.bitSlice 12 11 <<< 4)
+                      ||| (instr.bitSlice 5 5 <<< 3) ||| (instr.bitSlice 6 6 <<< 2)
+            if imm = 0 then None else C_ADDI4SPN {| rd = rdc; imm = imm |}
+        | 0b010 ->   // C.LW
+            let imm = (instr.bitSlice 5 5 <<< 6) ||| (instr.bitSlice 12 10 <<< 3) ||| (instr.bitSlice 6 6 <<< 2)
+            C_LW {| rd = rdc; rs1 = rs1c; imm = imm |}
+        | 0b110 ->   // C.SW
+            let imm = (instr.bitSlice 5 5 <<< 6) ||| (instr.bitSlice 12 10 <<< 3) ||| (instr.bitSlice 6 6 <<< 2)
+            C_SW {| rs1 = rs1c; rs2 = rdc; imm = imm |}
+        | 0b011 when rv64 ->   // C.LD
+            let imm = (instr.bitSlice 6 5 <<< 6) ||| (instr.bitSlice 12 10 <<< 3)
+            C_LD {| rd = rdc; rs1 = rs1c; imm = imm |}
+        | 0b111 when rv64 ->   // C.SD
+            let imm = (instr.bitSlice 6 5 <<< 6) ||| (instr.bitSlice 12 10 <<< 3)
+            C_SD {| rs1 = rs1c; rs2 = rdc; imm = imm |}
+        | _ -> None
+
+    // ---- Quadrant 1 ----
+    | 0b01 ->
+        match funct3 with
+        | 0b000 -> C_ADDI {| rd = rdw; imm = imm6 |}   // C.NOP / C.ADDI
+        | 0b001 when not rv64 -> C_JAL {| imm = cjImm instr |}   // C.JAL (RV32)
+        | 0b001 -> if rdw = 0 then None else C_ADDIW {| rd = rdw; imm = imm6 |}   // C.ADDIW (RV64)
+        | 0b010 -> C_LI {| rd = rdw; imm = imm6 |}     // C.LI
+        | 0b011 ->   // C.ADDI16SP (rd=2) / C.LUI (rd!=2)
+            if rdw = 2 then
+                let imm = ((instr.bitSlice 12 12 <<< 9) ||| (instr.bitSlice 4 3 <<< 7)
+                           ||| (instr.bitSlice 5 5 <<< 6) ||| (instr.bitSlice 2 2 <<< 5)
+                           ||| (instr.bitSlice 6 6 <<< 4)).signExtend 10
+                if imm = 0 then None else C_ADDI16SP {| imm = imm |}
+            // nzimm=0 is reserved; rd=x0 (nzimm!=0) is a HINT -> decode as C_LUI rd=0,
+            // which executes as a write to x0 (no-op), per the C-extension HINT rules.
+            elif imm6 = 0 then None
+            else C_LUI {| rd = rdw; imm = imm6 <<< 12 |}
+        | 0b100 ->   // misc-ALU
+            match instr.bitSlice 11 10 with
+            | 0b00 -> if shamtOk then C_SRLI {| rd = rs1c; shamt = shamt |} else None
+            | 0b01 -> if shamtOk then C_SRAI {| rd = rs1c; shamt = shamt |} else None
+            | 0b10 -> C_ANDI {| rd = rs1c; imm = imm6 |}
+            | _ ->   // 0b11: CA-format register-register
+                match instr.bitSlice 12 12, instr.bitSlice 6 5 with
+                | 0, 0b00 -> C_SUB {| rd = rs1c; rs2 = rdc |}
+                | 0, 0b01 -> C_XOR {| rd = rs1c; rs2 = rdc |}
+                | 0, 0b10 -> C_OR  {| rd = rs1c; rs2 = rdc |}
+                | 0, 0b11 -> C_AND {| rd = rs1c; rs2 = rdc |}
+                | 1, 0b00 when rv64 -> C_SUBW {| rd = rs1c; rs2 = rdc |}
+                | 1, 0b01 when rv64 -> C_ADDW {| rd = rs1c; rs2 = rdc |}
+                | _ -> None
+        | 0b101 -> C_J {| imm = cjImm instr |}
+        | 0b110 -> C_BEQZ {| rs1 = rs1c; imm = cbImm instr |}
+        | _     -> C_BNEZ {| rs1 = rs1c; imm = cbImm instr |}   // funct3 = 0b111
+
+    // ---- Quadrant 2 ----
+    | 0b10 ->
+        match funct3 with
+        | 0b000 -> if shamtOk then C_SLLI {| rd = rdw; shamt = shamt |} else None   // C.SLLI
+        | 0b010 ->   // C.LWSP (rd != 0)
+            let imm = (instr.bitSlice 3 2 <<< 6) ||| (instr.bitSlice 12 12 <<< 5) ||| (instr.bitSlice 6 4 <<< 2)
+            if rdw = 0 then None else C_LWSP {| rd = rdw; imm = imm |}
+        | 0b011 when rv64 ->   // C.LDSP (rd != 0)
+            let imm = (instr.bitSlice 4 2 <<< 6) ||| (instr.bitSlice 12 12 <<< 5) ||| (instr.bitSlice 6 5 <<< 3)
+            if rdw = 0 then None else C_LDSP {| rd = rdw; imm = imm |}
+        | 0b100 ->   // CR-format: C.JR / C.MV / C.EBREAK / C.JALR / C.ADD
+            match instr.bitSlice 12 12, rdw, rs2w with
+            | 0, _, 0 -> if rdw = 0 then None else C_JR {| rs1 = rdw |}
+            | 0, _, _ -> C_MV {| rd = rdw; rs2 = rs2w |}
+            | _, 0, 0 -> C_EBREAK
+            | _, _, 0 -> C_JALR {| rs1 = rdw |}
+            | _, _, _ -> C_ADD {| rd = rdw; rs2 = rs2w |}
+        | 0b110 ->   // C.SWSP
+            let imm = (instr.bitSlice 8 7 <<< 6) ||| (instr.bitSlice 12 9 <<< 2)
+            C_SWSP {| rs2 = rs2w; imm = imm |}
+        | 0b111 when rv64 ->   // C.SDSP
+            let imm = (instr.bitSlice 9 7 <<< 6) ||| (instr.bitSlice 12 10 <<< 3)
+            C_SDSP {| rs2 = rs2w; imm = imm |}
+        | _ -> None
+
+    | _ -> None
+
+// Current ISA print log message for current instruction step
+let verbosityMessage (instr : InstrField) (decodedInstr : InstructionC) (mstate : MachineState) =
+    let typeName = decodedInstr.GetType().Name
+    let instrMsg =
+        match decodedInstr with
+        | C_ADDI4SPN x | C_ADDI x | C_ADDIW x | C_LI x | C_LUI x
+        | C_ANDI x | C_LWSP x | C_LDSP x -> sprintf "x%d, %d" x.rd x.imm
+        | C_LW x | C_LD x -> sprintf "x%d, %d(x%d)" x.rd x.imm x.rs1
+        | C_SW x | C_SD x -> sprintf "x%d, %d(x%d)" x.rs2 x.imm x.rs1
+        | C_SRLI x | C_SRAI x | C_SLLI x -> sprintf "x%d, %d" x.rd x.shamt
+        | C_SUB x | C_XOR x | C_OR x | C_AND x | C_SUBW x | C_ADDW x | C_MV x | C_ADD x -> sprintf "x%d, x%d" x.rd x.rs2
+        | C_J x | C_JAL x | C_ADDI16SP x -> sprintf "%d" x.imm
+        | C_BEQZ x | C_BNEZ x -> sprintf "x%d, %d" x.rs1 x.imm
+        | C_JR x | C_JALR x -> sprintf "x%d" x.rs1
+        | C_SWSP x | C_SDSP x -> sprintf "x%d, %d(x2)" x.rs2 x.imm
+        | _ -> "Undef"
+    let pc = sprintf "%08x:" mstate.PC
+    let instr = sprintf "%04x" instr
+    let instrMsg = String.Format("{0,-7}{1}", typeName, instrMsg)
+    printfn "%s" (String.Format("{0,-12}{1,-12}{2}", pc, instr, instrMsg))

--- a/Decoder.fs
+++ b/Decoder.fs
@@ -18,46 +18,41 @@ let Decode (mstate : MachineState) (instr: InstrField) : execFunc option =
     let decM64 = M64.Decode mstate instr
     let decA = A.Decode instr
     let decA64 = A64.Decode instr
+    let decC = C.Decode mstate instr
 
-    // Check is instruction should be executed
-    let execI32 =
-        match mstate.Arch with
-        | RV32i | RV32im | RV32ia | RV32ima
-        | RV64i | RV64im | RV64ia | RV64ima when decI32 <> I.InstructionI.None -> true
-        | _ -> false
-    let execI64 =
-        match mstate.Arch with
-        | RV64i | RV64im | RV64ia | RV64ima when decI64 <> I64.InstructionI64.None -> true
-        | _ -> false
-    let execM32 =
-        match mstate.Arch with
-        | RV32im | RV64im | RV32ima | RV64ima when decM <> M.InstructionM.None -> true
-        | _ -> false
-    let execM64 =
-        match mstate.Arch with
-        | RV64im | RV64ima when decM64 <> M64.InstructionM64.None -> true
-        | _ -> false
-    let execA32 =
-        match mstate.Arch with
-        | RV32ia | RV64ia | RV32ima | RV64ima  when decA <> A.InstructionA.None -> true
-        | _ -> false
-    let execA64 =
-        match mstate.Arch with
-        | RV64ia | RV64ima when decA64 <> A64.InstructionA64.None -> true
-        | _ -> false
-    
+    let rv64 = mstate.Arch.archBits = RV64
+
+    // Each extension is gated by architecture support; base I is always present.
+    // (Compressed and 32-bit encodings are disjoint by inst[1:0], so only one decodes.)
+    let execI32 = decI32 <> I.InstructionI.None
+    let execI64 = rv64 && decI64 <> I64.InstructionI64.None
+    let execM32 = mstate.Arch.hasM && decM <> M.InstructionM.None
+    let execM64 = rv64 && mstate.Arch.hasM && decM64 <> M64.InstructionM64.None
+    let execA32 = mstate.Arch.hasA && decA <> A.InstructionA.None
+    let execA64 = rv64 && mstate.Arch.hasA && decA64 <> A64.InstructionA64.None
+    let execC   = mstate.Arch.hasC && decC <> C.InstructionC.None
+
+    // Instruction length is intrinsic to the encoding (inst[1:0]=11 => 32-bit, else
+    // 16-bit compressed). Bake it into the returned executor so PC/link advance
+    // correctly for any caller, without relying on InstrLen being set externally.
+    let len = if (instr &&& 0x3) = 0x3 then 4 else 2
+
     // Decoded instruction and execute ISA function
-    if execI32 then
-        Some(I.Execute decI32)
-    else if execI64 then
-        Some(I64.Execute decI64)
-    else if execM32 then
-        Some(M.Execute decM)
-    else if execM64 then
-        Some(M64.Execute decM64)
-    else if execA32 then
-        Some(A.Execute decA)
-    else if execA64 then
-        Some(A64.Execute decA64)
-    else
-        None
+    let executor =
+        if execI32 then
+            Some(I.Execute decI32)
+        else if execI64 then
+            Some(I64.Execute decI64)
+        else if execM32 then
+            Some(M.Execute decM)
+        else if execM64 then
+            Some(M64.Execute decM64)
+        else if execA32 then
+            Some(A.Execute decA)
+        else if execA64 then
+            Some(A64.Execute decA64)
+        else if execC then
+            Some(C.Execute decC)
+        else
+            None
+    executor |> Option.map (fun exec ms -> exec { ms with InstrLen = len })

--- a/ExecuteC.fs
+++ b/ExecuteC.fs
@@ -1,0 +1,48 @@
+module ISA.RISCV.Execute.C
+
+open ISA.RISCV.Arch
+open ISA.RISCV.Decode.C
+open ISA.RISCV.MachineState
+
+module I = ISA.RISCV.Execute.I
+module I64 = ISA.RISCV.Execute.I64
+
+// Execute C-instructions: each compressed op delegates to the base instruction
+// it expands to. PC advances by InstrLen (= 2 for compressed), so link addresses
+// and branch/jump targets are correct through the shared base semantics.
+let Execute (instr : InstructionC) (mstate : MachineState) =
+    match instr with
+    | C_ADDI4SPN i -> I.execADDI i.rd 2 i.imm mstate
+    | C_LW i       -> I.execLW i.rd i.rs1 i.imm mstate
+    | C_LD i       -> I64.execLD i.rd i.rs1 i.imm mstate
+    | C_SW i       -> I.execSW i.rs1 i.rs2 i.imm mstate
+    | C_SD i       -> I64.execSD i.rs1 i.rs2 i.imm mstate
+    | C_ADDI i     -> I.execADDI i.rd i.rd i.imm mstate
+    | C_ADDIW i    -> I64.execADDIW i.rd i.rd i.imm mstate
+    | C_LI i       -> I.execADDI i.rd 0 i.imm mstate
+    | C_LUI i      -> I.execLUI i.rd i.imm mstate
+    | C_ADDI16SP i -> I.execADDI 2 2 i.imm mstate
+    | C_SRLI i     -> I.execSRLI i.rd i.rd i.shamt mstate
+    | C_SRAI i     -> I.execSRAI i.rd i.rd i.shamt mstate
+    | C_ANDI i     -> I.execANDI i.rd i.rd i.imm mstate
+    | C_SUB i      -> I.execSUB i.rd i.rd i.rs2 mstate
+    | C_XOR i      -> I.execXOR i.rd i.rd i.rs2 mstate
+    | C_OR i       -> I.execOR i.rd i.rd i.rs2 mstate
+    | C_AND i      -> I.execAND i.rd i.rd i.rs2 mstate
+    | C_SUBW i     -> I64.execSUBW i.rd i.rd i.rs2 mstate
+    | C_ADDW i     -> I64.execADDW i.rd i.rd i.rs2 mstate
+    | C_J i        -> I.execJAL 0 i.imm mstate
+    | C_JAL i      -> I.execJAL 1 i.imm mstate
+    | C_BEQZ i     -> I.execBEQ i.rs1 0 i.imm mstate
+    | C_BNEZ i     -> I.execBNE i.rs1 0 i.imm mstate
+    | C_SLLI i     -> I.execSLLI i.rd i.rd i.shamt mstate
+    | C_LWSP i     -> I.execLW i.rd 2 i.imm mstate
+    | C_LDSP i     -> I64.execLD i.rd 2 i.imm mstate
+    | C_JR i       -> I.execJALR 0 i.rs1 0 mstate
+    | C_JALR i     -> I.execJALR 1 i.rs1 0 mstate
+    | C_MV i       -> I.execADD i.rd 0 i.rs2 mstate
+    | C_ADD i      -> I.execADD i.rd i.rd i.rs2 mstate
+    | C_EBREAK     -> I.execEBREAK mstate
+    | C_SWSP i     -> I.execSW 2 i.rs2 i.imm mstate
+    | C_SDSP i     -> I64.execSD 2 i.rs2 i.imm mstate
+    | _ -> mstate.setRunState (Trap InstructionExecute)

--- a/ExecuteI.fs
+++ b/ExecuteI.fs
@@ -21,7 +21,7 @@ let execAUIPC (rd : Register) (imm20 : InstrField) (mstate : MachineState) =
 // JALR - Jump Relative immediately
 let execJALR (rd : Register) (rs1 : Register) (imm12 : InstrField) (mstate : MachineState) =
     let newPC = ((mstate.getRegister rs1) + (int64 imm12)) &&& (~~~1L)
-    if newPC % 4L <> 0L then
+    if newPC % mstate.instrAlign <> 0L then
         mstate.setRunState (Trap JumpAddress)
     else if newPC = mstate.PC then
         mstate.setRunState Stopped
@@ -34,7 +34,7 @@ let execJALR (rd : Register) (rs1 : Register) (imm12 : InstrField) (mstate : Mac
 // JAL - Jump immediately
 let execJAL (rd : Register) (imm20 : InstrField) (mstate : MachineState) =
     let newPC = mstate.PC + int64 imm20
-    if newPC % 4L <> 0L then
+    if newPC % mstate.instrAlign <> 0L then
         mstate.setRunState (Trap JumpAddress)
     else if newPC = mstate.PC then
         mstate.setRunState Stopped
@@ -48,7 +48,7 @@ let branch (branchCheck : MachineInt -> MachineInt -> bool) (rs1 : Register) (rs
     let x1 = mstate.getRegister rs1
     let x2 = mstate.getRegister rs2
     let newPC = mstate.PC + int64 imm12
-    if newPC % 4L <> 0L then
+    if newPC % mstate.instrAlign <> 0L then
         mstate.setRunState (Trap BreakAddress)
     else if newPC = mstate.PC then
         mstate.setRunState Stopped
@@ -88,7 +88,7 @@ let execBLTU (rs1 : Register) (rs2 : Register) (imm12 : InstrField) (mstate : Ma
         | RV32 -> uint32 x1 < uint32 x2
         | _ -> uint64 x1 < uint64 x2
     let newPC = mstate.PC + int64 imm12
-    if newPC % 4L <> 0L then
+    if newPC % mstate.instrAlign <> 0L then
         mstate.setRunState (Trap BreakAddress)
     else if newPC = mstate.PC then
         mstate.setRunState Stopped
@@ -109,7 +109,7 @@ let execBGEU (rs1 : Register) (rs2: Register) (imm12 : InstrField) (mstate : Mac
         | _ -> uint64 x1 >= uint64 x2
 
     let newPC = mstate.PC + int64 imm12
-    if newPC % 4L <> 0L then
+    if newPC % mstate.instrAlign <> 0L then
         mstate.setRunState (Trap BreakAddress)
     else if newPC = mstate.PC then
         mstate.setRunState Stopped

--- a/MachineState.fs
+++ b/MachineState.fs
@@ -55,25 +55,26 @@ type MachineState = {
         let mem = Map.add addr (byte value) x.Memory
         { x with Memory = mem }
     
+    // Store `nBytes` little-endian bytes of `value` starting at `addr`.
+    // An explicit recursive loop keeps the only branch (i >= nBytes) fully
+    // exercised for any nBytes >= 1 (both the continue and stop sides are hit).
+    member private x.storeBytes (nBytes : int) (addr : MachineInt) (value : MachineInt) : MachineState =
+        let rec loop (ms : MachineState) i =
+            if i >= nBytes then ms
+            else loop (ms.setMemoryByte (addr + int64 i) (byte (value.bitSlice (i*8+7) (i*8)))) (i + 1)
+        loop x 0
+
     member x.storeMemoryByte (addr : MachineInt) (value : MachineInt) : MachineState =
-        let nBytes = 1
-        Array.fold (fun (ms : MachineState) (addr, data) -> ms.setMemoryByte addr data) x
-            [| for i in 0..(nBytes-1) -> (addr+(int64 i), byte (value.bitSlice (i*8+7) (i*8) )) |]
+        x.storeBytes 1 addr value
     
     member x.storeMemoryHalfWord (addr : MachineInt) (value : MachineInt) : MachineState =
-        let nBytes = 2
-        Array.fold (fun (ms : MachineState) (addr, data) -> ms.setMemoryByte addr data) x
-            [| for i in 0..(nBytes-1) -> (addr+(int64 i), byte (value.bitSlice (i*8+7) (i*8) )) |]
+        x.storeBytes 2 addr value
     
     member x.storeMemoryWord (addr : MachineInt) (value : MachineInt) : MachineState =
-        let nBytes = 4
-        Array.fold (fun (ms : MachineState) (addr, data) -> ms.setMemoryByte addr data) x
-            [| for i in 0..(nBytes-1) -> (addr+(int64 i), byte (value.bitSlice (i*8+7) (i*8) )) |]
+        x.storeBytes 4 addr value
 
     member x.storeMemoryDoubleWord (addr : MachineInt) (value : MachineInt) : MachineState =
-        let nBytes = 8
-        Array.fold (fun (ms : MachineState) (addr, data) -> ms.setMemoryByte addr data) x
-            [| for i in 0..(nBytes-1) -> (addr+(int64 i), byte (value.bitSlice (i*8+7) (i*8) )) |]
+        x.storeBytes 8 addr value
         
     member x.setRunState state =
         { x with RunState = state }

--- a/MachineState.fs
+++ b/MachineState.fs
@@ -18,6 +18,7 @@ type MachineState = {
         Arch:       Architecture
         RunState:   RunMachineState
         Reservation: int64 option
+        InstrLen:   int
     } with
     member x.getRegister(reg: Register) : MachineInt =
         if reg = 0 then
@@ -37,7 +38,10 @@ type MachineState = {
         { x with PC = x.alignByArchUnsign pc }
 
     member x.incPC : MachineState =
-        x.setPC (x.PC + 4L)
+        x.setPC (x.PC + int64 x.InstrLen)
+    // Instruction alignment (IALIGN): 2 bytes when C is supported, else 4.
+    member x.instrAlign : int64 =
+        if x.Arch.hasC then 2L else 4L
 
     member x.getMemory(addr : int64) =
         let addr = x.alignByArchUnsign addr
@@ -100,4 +104,5 @@ let InitMachineState mem arch verbosity : MachineState =
         Verbosity    = verbosity
         RunState     = RunMachineState.NotRun
         Reservation  = None
+        InstrLen     = 4
     }

--- a/Program.fs
+++ b/Program.fs
@@ -17,6 +17,7 @@ let main argv =
                 let res = Run.Run x
                 printfn "Result state: %A" res.RunState
             with ex ->
-                let file = if x.Files.Value.Length > 0 then x.Files.Value.[0] else "<unknown>"
-                printfn $"Error: failed to load or run '{file}': {ex.Message}"
+                // CheckRequired above guarantees Files is Some and non-empty here,
+                // so indexing [0] is safe (the prior defensive else was dead code).
+                printfn $"Error: failed to load or run '{x.Files.Value.[0]}': {ex.Message}"
     0 // return an integer exit code

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Technical Group constituted by The RISC-V Foundation
   - [x] Tests for Standard extension M RV32/RV64
   - [x] Standard extension A (atomic memory ops)
   - [x] Tests for Standard extension A RV32/RV64
+  - [x] Standard extension C (Compressed 16-bit instructions)
+  - [x] Tests for Standard extension C RV32/RV64
 * Features under development
-  * Standard extension C (Compressed 16-bit instructions)
   * Standard extension F (Single-precision floating point)
   * Standard extension D (Double-precision floating point)
   * Privilege Level M (Machine)

--- a/Run.fs
+++ b/Run.fs
@@ -41,7 +41,14 @@ let readElfFile (file : string) : Map<int64, byte> =
 // Get instruction from current Machine State that related to
 // current PC as memory address for loading instruction data for Decoding
 let fetchInstruction (mstate : MachineState) : InstrField option =
-    loadWord mstate.Memory mstate.PC
+    match loadHalfWord mstate.Memory mstate.PC with
+    | None -> None
+    | Some hw ->
+        // 32-bit instruction iff inst[1:0] = 0b11, otherwise 16-bit compressed.
+        if (int hw &&& 0x3) = 0x3 then
+            loadWord mstate.Memory mstate.PC
+        else
+            Some(int32 (uint16 hw))
 
 // Basic RISC-V run life cycle (FSM). `steps` bounds execution so a non-terminating
 // program (e.g. a backward self-branch) aborts with a StepLimit trap instead of hanging.

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -47,6 +47,7 @@
       <Compile Include="rv64a\amo.fs" />
       <Compile Include="rv64a\amoD.fs" />
       <Compile Include="rv64a\amoSem.fs" />
+      <Compile Include="rvc\c.fs" />
       <Compile Include="run\run.fs" />
       <Compile Include="unit\units.fs" />
       <Compile Include="unit\cli.fs" />

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -52,6 +52,7 @@
       <Compile Include="unit\units.fs" />
       <Compile Include="unit\cli.fs" />
       <Compile Include="unit\decode.fs" />
+      <Compile Include="unit\branch.fs" />
       <Compile Include="unit\execute.fs" />
       <Compile Include="unit\app.fs" />
         

--- a/Tests/rvc/c.fs
+++ b/Tests/rvc/c.fs
@@ -1,0 +1,324 @@
+module Tests.rvc.c
+
+open Xunit
+
+open ISA.RISCV
+open ISA.RISCV.Arch
+open ISA.RISCV.MachineState
+open ISA.RISCV.Utils.Bits
+
+module DC = ISA.RISCV.Decode.C
+module EC = ISA.RISCV.Execute.C
+
+// ---- 16-bit C instruction encoders (spec bit layout; anchored by the canonical test) ----
+let private bit v pos = (v &&& 1) <<< pos
+let private fld v hi lo = (v &&& ((1 <<< (hi-lo+1)) - 1)) <<< lo
+let private cc r = r - 8   // wide reg (x8..x15) -> 3-bit compressed field
+let private cjEnc f3 imm =
+    fld f3 15 13 ||| bit (imm>>>11) 12 ||| bit (imm>>>4) 11 ||| fld ((imm>>>8)&&&0x3) 10 9 ||| bit (imm>>>10) 8
+    ||| bit (imm>>>6) 7 ||| bit (imm>>>7) 6 ||| fld ((imm>>>1)&&&0x7) 5 3 ||| bit (imm>>>5) 2 ||| 0b01
+let private cADDI4SPN rd imm = fld 0b000 15 13 ||| fld ((imm>>>6)&&&0xf) 10 7 ||| fld ((imm>>>4)&&&0x3) 12 11 ||| bit (imm>>>3) 5 ||| bit (imm>>>2) 6 ||| fld (cc rd) 4 2
+let private cLW rd rs1 imm = fld 0b010 15 13 ||| bit (imm>>>6) 5 ||| fld ((imm>>>3)&&&0x7) 12 10 ||| bit (imm>>>2) 6 ||| fld (cc rs1) 9 7 ||| fld (cc rd) 4 2
+let private cSW rs1 rs2 imm = fld 0b110 15 13 ||| bit (imm>>>6) 5 ||| fld ((imm>>>3)&&&0x7) 12 10 ||| bit (imm>>>2) 6 ||| fld (cc rs1) 9 7 ||| fld (cc rs2) 4 2
+let private cLD rd rs1 imm = fld 0b011 15 13 ||| fld ((imm>>>6)&&&0x3) 6 5 ||| fld ((imm>>>3)&&&0x7) 12 10 ||| fld (cc rs1) 9 7 ||| fld (cc rd) 4 2
+let private cSD rs1 rs2 imm = fld 0b111 15 13 ||| fld ((imm>>>6)&&&0x3) 6 5 ||| fld ((imm>>>3)&&&0x7) 12 10 ||| fld (cc rs1) 9 7 ||| fld (cc rs2) 4 2
+let private cADDI rd imm = fld 0b000 15 13 ||| bit (imm>>>5) 12 ||| fld rd 11 7 ||| fld (imm&&&0x1f) 6 2 ||| 0b01
+let private cADDIW rd imm = fld 0b001 15 13 ||| bit (imm>>>5) 12 ||| fld rd 11 7 ||| fld (imm&&&0x1f) 6 2 ||| 0b01
+let private cJAL imm = cjEnc 0b001 imm
+let private cLI rd imm = fld 0b010 15 13 ||| bit (imm>>>5) 12 ||| fld rd 11 7 ||| fld (imm&&&0x1f) 6 2 ||| 0b01
+let private cLUI rd n6 = fld 0b011 15 13 ||| bit (n6>>>5) 12 ||| fld rd 11 7 ||| fld (n6&&&0x1f) 6 2 ||| 0b01
+let private cADDI16SP imm = fld 0b011 15 13 ||| bit (imm>>>9) 12 ||| fld 2 11 7 ||| fld ((imm>>>7)&&&0x3) 4 3 ||| bit (imm>>>6) 5 ||| bit (imm>>>5) 2 ||| bit (imm>>>4) 6 ||| 0b01
+let private cSRLI rd shamt = fld 0b100 15 13 ||| bit (shamt>>>5) 12 ||| fld 0b00 11 10 ||| fld (cc rd) 9 7 ||| fld (shamt&&&0x1f) 6 2 ||| 0b01
+let private cSRAI rd shamt = fld 0b100 15 13 ||| bit (shamt>>>5) 12 ||| fld 0b01 11 10 ||| fld (cc rd) 9 7 ||| fld (shamt&&&0x1f) 6 2 ||| 0b01
+let private cANDI rd imm = fld 0b100 15 13 ||| bit (imm>>>5) 12 ||| fld 0b10 11 10 ||| fld (cc rd) 9 7 ||| fld (imm&&&0x1f) 6 2 ||| 0b01
+let private caEnc b12 sub rd rs2 = fld 0b100 15 13 ||| (b12<<<12) ||| fld 0b11 11 10 ||| fld (cc rd) 9 7 ||| fld sub 6 5 ||| fld (cc rs2) 4 2 ||| 0b01
+let private cJ imm = cjEnc 0b101 imm
+let private cBEQZ rs1 imm = fld 0b110 15 13 ||| bit (imm>>>8) 12 ||| fld ((imm>>>3)&&&0x3) 11 10 ||| fld (cc rs1) 9 7 ||| fld ((imm>>>6)&&&0x3) 6 5 ||| fld ((imm>>>1)&&&0x3) 4 3 ||| bit (imm>>>5) 2 ||| 0b01
+let private cBNEZ rs1 imm = fld 0b111 15 13 ||| bit (imm>>>8) 12 ||| fld ((imm>>>3)&&&0x3) 11 10 ||| fld (cc rs1) 9 7 ||| fld ((imm>>>6)&&&0x3) 6 5 ||| fld ((imm>>>1)&&&0x3) 4 3 ||| bit (imm>>>5) 2 ||| 0b01
+let private cSLLI rd shamt = fld 0b000 15 13 ||| bit (shamt>>>5) 12 ||| fld rd 11 7 ||| fld (shamt&&&0x1f) 6 2 ||| 0b10
+let private cLWSP rd imm = fld 0b010 15 13 ||| fld ((imm>>>6)&&&0x3) 3 2 ||| bit (imm>>>5) 12 ||| fld ((imm>>>2)&&&0x7) 6 4 ||| fld rd 11 7 ||| 0b10
+let private cLDSP rd imm = fld 0b011 15 13 ||| fld ((imm>>>6)&&&0x7) 4 2 ||| bit (imm>>>5) 12 ||| fld ((imm>>>3)&&&0x3) 6 5 ||| fld rd 11 7 ||| 0b10
+let private crEnc b12 rd rs2 = fld 0b100 15 13 ||| (b12<<<12) ||| fld rd 11 7 ||| fld rs2 6 2 ||| 0b10
+let private cSWSP rs2 imm = fld 0b110 15 13 ||| fld ((imm>>>6)&&&0x3) 8 7 ||| fld ((imm>>>2)&&&0xf) 12 9 ||| fld rs2 6 2 ||| 0b10
+let private cSDSP rs2 imm = fld 0b111 15 13 ||| fld ((imm>>>6)&&&0x7) 9 7 ||| fld ((imm>>>3)&&&0x7) 12 10 ||| fld rs2 6 2 ||| 0b10
+
+// Anchor: encoders reproduce well-known real encodings, validating the bit layout.
+[<Fact>]
+let ``encoders match canonical hex`` () =
+    Assert.Equal(0x0001, cADDI 0 0)      // c.nop
+    Assert.Equal(0x0085, cADDI 1 1)
+    Assert.Equal(0x4085, cLI 1 1)
+    Assert.Equal(0x8082, crEnc 0 1 0)    // c.jr x1 (ret)
+    Assert.Equal(0x808a, crEnc 0 1 2)    // c.mv x1,x2
+    Assert.Equal(0x908a, crEnc 1 1 2)    // c.add x1,x2
+    Assert.Equal(0x9002, crEnc 1 0 0)    // c.ebreak
+    Assert.Equal(0x9082, crEnc 1 1 0)    // c.jalr x1
+    Assert.Equal(0x4082, cLWSP 1 0)
+    Assert.Equal(0xc006, cSWSP 1 0)
+
+// No manual InstrLen: Decoder.Decode derives it from inst[1:0] and bakes it into
+// the executor, so a compressed op advances PC by 2 without the caller setting it.
+let private st (arch : Architecture) = MachineState.InitMachineState Map.empty arch false
+let private run (m : MachineState) (instr : int) =
+    let e = Decoder.Decode m instr
+    Assert.NotEqual(e, None)
+    e.Value m
+
+// ---- Quadrant 0 ----
+[<Fact>]
+let ``C.ADDI4SPN`` () =
+    let m = run ((st RV32ic).setRegister 2 0x1000L) (cADDI4SPN 8 16)
+    Assert.Equal(0x1010L, m.getRegister 8)
+    Assert.Equal(0x80000002L, m.PC)
+
+[<Fact>]
+let ``C.LW`` () =
+    let m = ((st RV32ic).setRegister 8 0x2000L).storeMemoryWord 0x2004L 0xABCDL
+    let m = run m (cLW 9 8 4)
+    Assert.Equal(0xABCDL, int64 (loadWord m.Memory 0x2004L).Value)
+    Assert.Equal(0xABCDL, m.getRegister 9)
+
+[<Fact>]
+let ``C.SW`` () =
+    let m = ((st RV32ic).setRegister 8 0x2000L).setRegister 9 0x1234L
+    let m = run m (cSW 8 9 4)
+    Assert.Equal(0x1234L, int64 (loadWord m.Memory 0x2004L).Value)
+
+[<Fact>]
+let ``C.LD (RV64)`` () =
+    let m = ((st RV64ic).setRegister 8 0x2000L).storeMemoryDoubleWord 0x2008L 0x1122334455667788L
+    let m = run m (cLD 9 8 8)
+    Assert.Equal(0x1122334455667788L, m.getRegister 9)
+
+[<Fact>]
+let ``C.SD (RV64)`` () =
+    let m = ((st RV64ic).setRegister 8 0x2000L).setRegister 9 0xDEADBEEFCAFEL
+    let m = run m (cSD 8 9 8)
+    Assert.Equal(0xDEADBEEFCAFEL, (loadDouble m.Memory 0x2008L).Value)
+
+// ---- Quadrant 1 ----
+[<Fact>]
+let ``C.ADDI`` () =
+    let m = run ((st RV32ic).setRegister 5 10L) (cADDI 5 -3)
+    Assert.Equal(7L, m.getRegister 5)
+    Assert.Equal(0x80000002L, m.PC)
+
+[<Fact>]
+let ``C.NOP`` () =
+    let m = run (st RV32ic) (cADDI 0 0)
+    Assert.Equal(0L, m.getRegister 0)
+    Assert.Equal(0x80000002L, m.PC)
+
+[<Fact>]
+let ``C.JAL (RV32) links PC+2`` () =
+    let m = run ((st RV32ic).setPC 0x1000L) (cJAL 16)
+    Assert.Equal(0x1010L, m.PC)
+    Assert.Equal(0x1002L, m.getRegister 1)
+
+[<Fact>]
+let ``C.ADDIW (RV64)`` () =
+    let m = run ((st RV64ic).setRegister 5 0xFFFFFFFFL) (cADDIW 5 1)
+    Assert.Equal(0L, m.getRegister 5)
+
+[<Fact>]
+let ``C.ADDIW rd, 0 acts as sext.w (RV64)`` () =
+    // imm=0 is VALID for C.ADDIW (not reserved): addiw rd,rd,0 == sext.w rd.
+    // Upper 32 bits are discarded; bit 31 is sign-extended through bits 63:32.
+    let neg = run ((st RV64ic).setRegister 5 0x1234567880000000L) (cADDIW 5 0)
+    Assert.Equal(-2147483648L, neg.getRegister 5)   // 0xFFFFFFFF_80000000
+    let pos = run ((st RV64ic).setRegister 6 0x1234567800000123L) (cADDIW 6 0)
+    Assert.Equal(0x123L, pos.getRegister 6)          // 0x00000000_00000123
+
+[<Fact>]
+let ``C.LI`` () =
+    let m = run (st RV32ic) (cLI 5 -1)
+    Assert.Equal(-1L, m.getRegister 5)
+
+[<Fact>]
+let ``C.ADDI16SP`` () =
+    let m = run ((st RV32ic).setRegister 2 0x1000L) (cADDI16SP 32)
+    Assert.Equal(0x1020L, m.getRegister 2)
+
+[<Fact>]
+let ``C.LUI`` () =
+    let m = run (st RV32ic) (cLUI 5 1)
+    Assert.Equal(0x1000L, m.getRegister 5)
+
+[<Fact>]
+let ``C.LUI rd=x0 is a HINT (no-op, not illegal)`` () =
+    // rd=x0, nzimm!=0 is a HINT: must decode (not trap) and run as a no-op.
+    // PC+2 also confirms InstrLen is derived by Decode (st no longer sets it).
+    let m = run (st RV32ic) (cLUI 0 1)
+    Assert.Equal(0L, m.getRegister 0)
+    Assert.Equal(0x80000002L, m.PC)
+
+[<Fact>]
+let ``C.SRLI`` () =
+    let m = run ((st RV32ic).setRegister 8 0xF0L) (cSRLI 8 4)
+    Assert.Equal(0xFL, m.getRegister 8)
+
+[<Fact>]
+let ``C.SRAI`` () =
+    let m = run ((st RV32ic).setRegister 8 -16L) (cSRAI 8 2)
+    Assert.Equal(-4L, m.getRegister 8)
+
+[<Fact>]
+let ``C.ANDI`` () =
+    let m = run ((st RV32ic).setRegister 8 0xFFL) (cANDI 8 0xF)
+    Assert.Equal(0xFL, m.getRegister 8)
+
+[<Fact>]
+let ``C.SUB`` () =
+    let m = run (((st RV32ic).setRegister 8 10L).setRegister 9 3L) (caEnc 0 0b00 8 9)
+    Assert.Equal(7L, m.getRegister 8)
+
+[<Fact>]
+let ``C.XOR`` () =
+    let m = run (((st RV32ic).setRegister 8 0b1100L).setRegister 9 0b1010L) (caEnc 0 0b01 8 9)
+    Assert.Equal(0b0110L, m.getRegister 8)
+
+[<Fact>]
+let ``C.OR`` () =
+    let m = run (((st RV32ic).setRegister 8 0b1100L).setRegister 9 0b1010L) (caEnc 0 0b10 8 9)
+    Assert.Equal(0b1110L, m.getRegister 8)
+
+[<Fact>]
+let ``C.AND`` () =
+    let m = run (((st RV32ic).setRegister 8 0b1100L).setRegister 9 0b1010L) (caEnc 0 0b11 8 9)
+    Assert.Equal(0b1000L, m.getRegister 8)
+
+[<Fact>]
+let ``C.SUBW (RV64)`` () =
+    let m = run (((st RV64ic).setRegister 8 10L).setRegister 9 3L) (caEnc 1 0b00 8 9)
+    Assert.Equal(7L, m.getRegister 8)
+
+[<Fact>]
+let ``C.ADDW (RV64)`` () =
+    let m = run (((st RV64ic).setRegister 8 10L).setRegister 9 3L) (caEnc 1 0b01 8 9)
+    Assert.Equal(13L, m.getRegister 8)
+
+[<Fact>]
+let ``C.J`` () =
+    Assert.Equal(0x80000010L, (run (st RV32ic) (cJ 16)).PC)
+
+[<Fact>]
+let ``C.J to a 2-byte-aligned target (IALIGN=2)`` () =
+    Assert.Equal(0x80000012L, (run (st RV32ic) (cJ 18)).PC)
+
+[<Fact>]
+let ``C.BEQZ taken / not taken`` () =
+    Assert.Equal(0x80000010L, (run ((st RV32ic).setRegister 8 0L) (cBEQZ 8 16)).PC)
+    Assert.Equal(0x80000002L, (run ((st RV32ic).setRegister 8 5L) (cBEQZ 8 16)).PC)
+
+[<Fact>]
+let ``C.BNEZ taken / not taken`` () =
+    Assert.Equal(0x80000010L, (run ((st RV32ic).setRegister 8 5L) (cBNEZ 8 16)).PC)
+    Assert.Equal(0x80000002L, (run ((st RV32ic).setRegister 8 0L) (cBNEZ 8 16)).PC)
+
+// ---- Quadrant 2 ----
+[<Fact>]
+let ``C.SLLI`` () =
+    Assert.Equal(16L, (run ((st RV32ic).setRegister 5 1L) (cSLLI 5 4)).getRegister 5)
+
+[<Fact>]
+let ``C.SLLI shamt 32 (RV64)`` () =
+    Assert.Equal(0x100000000L, (run ((st RV64ic).setRegister 5 1L) (cSLLI 5 32)).getRegister 5)
+
+[<Fact>]
+let ``C.LWSP`` () =
+    let m = ((st RV32ic).setRegister 2 0x3000L).storeMemoryWord 0x3004L 0x55L
+    Assert.Equal(0x55L, (run m (cLWSP 5 4)).getRegister 5)
+
+[<Fact>]
+let ``C.LDSP (RV64)`` () =
+    let m = ((st RV64ic).setRegister 2 0x3000L).storeMemoryDoubleWord 0x3008L 0x99L
+    Assert.Equal(0x99L, (run m (cLDSP 5 8)).getRegister 5)
+
+[<Fact>]
+let ``C.JR`` () =
+    let m = run ((st RV32ic).setRegister 5 0x80001000L) (crEnc 0 5 0)
+    Assert.Equal(0x80001000L, m.PC)
+
+[<Fact>]
+let ``C.MV`` () =
+    Assert.Equal(42L, (run ((st RV32ic).setRegister 6 42L) (crEnc 0 5 6)).getRegister 5)
+
+[<Fact>]
+let ``C.EBREAK`` () =
+    match (run (st RV32ic) (crEnc 1 0 0)).RunState with
+    | Trap EBreak -> () | s -> Assert.True(false, sprintf "%A" s)
+
+[<Fact>]
+let ``C.JALR links PC+2`` () =
+    let m = run (((st RV32ic).setPC 0x1000L).setRegister 5 0x2000L) (crEnc 1 5 0)
+    Assert.Equal(0x2000L, m.PC)
+    Assert.Equal(0x1002L, m.getRegister 1)
+
+[<Fact>]
+let ``C.ADD`` () =
+    let m = run (((st RV32ic).setRegister 5 10L).setRegister 6 5L) (crEnc 1 5 6)
+    Assert.Equal(15L, m.getRegister 5)
+
+[<Fact>]
+let ``C.SWSP`` () =
+    let m = run (((st RV32ic).setRegister 2 0x4000L).setRegister 5 0x77L) (cSWSP 5 4)
+    Assert.Equal(0x77L, int64 (loadWord m.Memory 0x4004L).Value)
+
+[<Fact>]
+let ``C.SDSP (RV64)`` () =
+    let m = run (((st RV64ic).setRegister 2 0x4000L).setRegister 5 0x88L) (cSDSP 5 8)
+    Assert.Equal(0x88L, (loadDouble m.Memory 0x4008L).Value)
+
+// ---- illegal / reserved encodings decode to None ----
+[<Fact>]
+let ``reserved and FP-compressed encodings decode to None`` () =
+    let m32 = st RV32ic
+    let m64 = st RV64ic
+    Assert.Equal(DC.None, DC.Decode m32 0x0000)             // all-zero (illegal)
+    Assert.Equal(DC.None, DC.Decode m32 (cADDI4SPN 8 0))    // C.ADDI4SPN nzuimm=0
+    Assert.Equal(DC.None, DC.Decode m32 0x2000)             // Q0 funct3=001 (C.FLD, needs D)
+    Assert.Equal(DC.None, DC.Decode m32 0x6000)             // RV32 Q0 funct3=011 (C.FLW, needs F)
+    Assert.Equal(DC.None, DC.Decode m32 0x2002)             // Q2 funct3=001 (C.FLDSP, needs D)
+    Assert.Equal(DC.None, DC.Decode m32 (caEnc 1 0b00 8 9)) // RV32 reserved CA (bit12=1)
+    Assert.Equal(DC.None, DC.Decode m64 (caEnc 1 0b10 8 9)) // RV64 reserved CA (sub=10)
+    Assert.Equal(DC.None, DC.Decode m32 (cSLLI 5 32))       // RV32 C.SLLI shamt>=32
+    Assert.Equal(DC.None, DC.Decode m32 (cLWSP 0 4))        // C.LWSP rd=0
+    Assert.Equal(DC.None, DC.Decode m32 (crEnc 0 0 0))      // C.JR rd=0
+    Assert.Equal(DC.None, DC.Decode m32 (cADDI16SP 0))      // C.ADDI16SP nzimm=0
+    Assert.Equal(DC.None, DC.Decode m32 (cLUI 5 0))         // C.LUI nzimm=0
+    Assert.Equal(DC.None, DC.Decode m64 (cADDIW 0 1))       // C.ADDIW rd=0
+
+[<Fact>]
+let ``C Execute None traps`` () =
+    match (EC.Execute DC.None (st RV32ic)).RunState with
+    | Trap InstructionExecute -> () | s -> Assert.True(false, sprintf "%A" s)
+
+// ---- fetch/PC integration: a compressed program runs through runSteps ----
+[<Fact>]
+let ``runSteps executes a compressed program (PC += 2)`` () =
+    // c.li x5,5 ; c.li x6,3 ; c.add x5,x6 ; c.ebreak
+    let prog = [ cLI 5 5; cLI 6 3; crEnc 1 5 6; crEnc 1 0 0 ]
+    let m = (MachineState.InitMachineState Map.empty RV32ic false).setRunState RunMachineState.Run
+    let m = prog |> List.mapi (fun i w -> (0x80000000L + int64 (i * 2), w))
+                 |> List.fold (fun (s : MachineState) (a, w) -> s.storeMemoryHalfWord a (int64 w)) m
+    let m = Run.runSteps 10 m
+    Assert.Equal(8L, m.getRegister 5)
+    match m.RunState with
+    | Trap EBreak -> () | s -> Assert.True(false, sprintf "%A" s)
+
+// ---- verbosityMessage: cover every output group ----
+[<Fact>]
+let ``C verbosityMessage covers all groups`` () =
+    let m = st RV64ic
+    let vm w = DC.verbosityMessage w (DC.Decode m w) m
+    vm (cADDI 1 1)
+    vm (cLW 9 8 4)
+    vm (cSW 8 9 4)
+    vm (cSLLI 5 4)
+    vm (caEnc 0 0b00 8 9)
+    vm (cJ 16)
+    vm (cBEQZ 8 16)
+    vm (crEnc 0 1 0)
+    vm (cSWSP 5 4)
+    DC.verbosityMessage 0 DC.None m
+    DC.verbosityMessage 0 DC.C_EBREAK m

--- a/Tests/rvc/c.fs
+++ b/Tests/rvc/c.fs
@@ -287,6 +287,9 @@ let ``reserved and FP-compressed encodings decode to None`` () =
     Assert.Equal(DC.None, DC.Decode m32 (cADDI16SP 0))      // C.ADDI16SP nzimm=0
     Assert.Equal(DC.None, DC.Decode m32 (cLUI 5 0))         // C.LUI nzimm=0
     Assert.Equal(DC.None, DC.Decode m64 (cADDIW 0 1))       // C.ADDIW rd=0
+    Assert.Equal(DC.None, DC.Decode m32 (cSRLI 8 32))       // C.SRLI shamt>=32 RV32 (shamtOk=false)
+    Assert.Equal(DC.None, DC.Decode m32 (cSRAI 8 32))       // C.SRAI shamt>=32 RV32 (shamtOk=false)
+    Assert.Equal(DC.None, DC.Decode m64 (cLDSP 0 8))        // C.LDSP rd=0
 
 [<Fact>]
 let ``C Execute None traps`` () =
@@ -308,17 +311,22 @@ let ``runSteps executes a compressed program (PC += 2)`` () =
 
 // ---- verbosityMessage: cover every output group ----
 [<Fact>]
-let ``C verbosityMessage covers all groups`` () =
+let ``C verbosityMessage covers every constructor`` () =
     let m = st RV64ic
     let vm w = DC.verbosityMessage w (DC.Decode m w) m
-    vm (cADDI 1 1)
-    vm (cLW 9 8 4)
-    vm (cSW 8 9 4)
-    vm (cSLLI 5 4)
-    vm (caEnc 0 0b00 8 9)
-    vm (cJ 16)
-    vm (cBEQZ 8 16)
-    vm (crEnc 0 1 0)
-    vm (cSWSP 5 4)
-    DC.verbosityMessage 0 DC.None m
-    DC.verbosityMessage 0 DC.C_EBREAK m
+    // RV64ic decodes every constructor except C.JAL (RV32-only)
+    vm (cADDI4SPN 8 16); vm (cADDI 1 1); vm (cADDIW 5 1); vm (cLI 5 1); vm (cLUI 5 1)
+    vm (cANDI 8 0xF); vm (cLWSP 5 4); vm (cLDSP 5 8)
+    vm (cLW 9 8 4); vm (cLD 9 8 8); vm (cSW 8 9 4); vm (cSD 8 9 8)
+    vm (cSRLI 8 4); vm (cSRAI 8 2); vm (cSLLI 5 4)
+    vm (caEnc 0 0b00 8 9); vm (caEnc 0 0b01 8 9); vm (caEnc 0 0b10 8 9); vm (caEnc 0 0b11 8 9)
+    vm (caEnc 1 0b00 8 9); vm (caEnc 1 0b01 8 9)              // C.SUBW C.ADDW
+    vm (cJ 16); vm (cADDI16SP 32); vm (cBEQZ 8 16); vm (cBNEZ 8 16)
+    vm (crEnc 0 5 0); vm (crEnc 1 5 0)                        // C.JR C.JALR
+    vm (crEnc 0 5 6); vm (crEnc 1 5 6)                        // C.MV C.ADD
+    vm (cSWSP 5 4); vm (cSDSP 5 8)
+    // C.JAL is RV32-only (on RV64 funct3=001 decodes as C.ADDIW)
+    let m32 = st RV32ic
+    DC.verbosityMessage (cJAL 16) (DC.Decode m32 (cJAL 16)) m32
+    DC.verbosityMessage 0 DC.None m         // _ -> "Undef"
+    DC.verbosityMessage 0 DC.C_EBREAK m     // _ -> "Undef"

--- a/Tests/unit/branch.fs
+++ b/Tests/unit/branch.fs
@@ -1,0 +1,99 @@
+module Tests.unit.branch
+
+open Xunit
+
+open ISA.RISCV
+open ISA.RISCV.Arch
+open ISA.RISCV.MachineState
+
+module DI   = ISA.RISCV.Decode.I
+module DI64 = ISA.RISCV.Decode.I64
+module DM   = ISA.RISCV.Decode.M
+module DM64 = ISA.RISCV.Decode.M64
+module DA   = ISA.RISCV.Decode.A
+module DA64 = ISA.RISCV.Decode.A64
+
+let private m32 = MachineState.InitMachineState Map.empty RV32i false
+let private m64 = MachineState.InitMachineState Map.empty RV64ima false
+
+// =====================================================================
+// verbosityMessage: decode one real encoding per constructor so every
+// OR-pattern alternative arm is exercised (full branch coverage).
+// (Anonymous records can't cross the assembly boundary, so we decode
+//  rather than build the DU values directly.)
+// =====================================================================
+
+[<Fact>]
+let ``I verbosityMessage: every constructor arm`` () =
+    [ 0x000000b7                                                              // LUI
+      0x00000097                                                              // AUIPC
+      0x0000006f                                                              // JAL
+      0x00000067                                                              // JALR
+      0x00000063; 0x00001063; 0x00004063; 0x00005063; 0x00006063; 0x00007063 // BEQ BNE BLT BGE BLTU BGEU
+      0x00000083; 0x00001083; 0x00002083; 0x00004083; 0x00005083             // LB LH LW LBU LHU
+      0x00000023; 0x00001023; 0x00002023                                     // SB SH SW
+      0x00000013; 0x00002013; 0x00003013; 0x00004013; 0x00006013; 0x00007013 // ADDI SLTI SLTIU XORI ORI ANDI
+      0x00001013; 0x00005013; 0x40005013                                     // SLLI SRLI SRAI
+      0x00000033; 0x40000033; 0x00001033; 0x00002033; 0x00003033             // ADD SUB SLL SLT SLTU
+      0x00004033; 0x00005033; 0x40005033; 0x00006033; 0x00007033             // XOR SRL SRA OR AND
+      0x0000000f; 0x00000073; 0x00100073 ]                                   // FENCE ECALL EBREAK
+    |> List.iter (fun w -> DI.verbosityMessage w (DI.Decode m32 w) m32)
+    DI.verbosityMessage 0 DI.None m32   // _ -> "Undef"
+
+[<Fact>]
+let ``I64 verbosityMessage: every constructor arm`` () =
+    [ 0x00006003; 0x00003003; 0x00003023; 0x0000001b                         // LWU LD SD ADDIW
+      0x0000101b; 0x0000501b; 0x4000501b                                     // SLLIW SRLIW SRAIW
+      0x0000003b; 0x4000003b; 0x0000103b; 0x0000503b; 0x4000503b ]           // ADDW SUBW SLLW SRLW SRAW
+    |> List.iter (fun w -> DI64.verbosityMessage w (DI64.Decode w) m64)
+    DI64.verbosityMessage 0 DI64.None m64
+
+[<Fact>]
+let ``M verbosityMessage: every constructor arm`` () =
+    [ 0x02000033; 0x02001033; 0x02002033; 0x02003033                         // MUL MULH MULHSU MULHU
+      0x02004033; 0x02005033; 0x02006033; 0x02007033 ]                       // DIV DIVU REM REMU
+    |> List.iter (fun w -> DM.verbosityMessage w (DM.Decode m64 w) m64)
+    DM.verbosityMessage 0 DM.None m64
+
+[<Fact>]
+let ``M64 verbosityMessage: every constructor arm`` () =
+    [ 0x0200003b; 0x0200403b; 0x0200503b; 0x0200603b; 0x0200703b ]           // MULW DIVW DIVUW REMW REMUW
+    |> List.iter (fun w -> DM64.verbosityMessage w (DM64.Decode m64 w) m64)
+    DM64.verbosityMessage 0 DM64.None m64
+
+[<Fact>]
+let ``A verbosityMessage: every constructor arm`` () =
+    [ 0x1000202f; 0x1800202f; 0x0800202f; 0x0000202f; 0x2000202f; 0x6000202f // LR SC SWAP ADD XOR AND
+      0x4000202f; 0x8000202f; 0xA000202f; 0xC000202f; 0xE000202f ]           // OR MIN MAX MINU MAXU
+    |> List.iter (fun w -> DA.verbosityMessage w (DA.Decode w) m64)
+    DA.verbosityMessage 0 DA.None m64
+
+[<Fact>]
+let ``A64 verbosityMessage: every constructor arm`` () =
+    [ 0x1000302f; 0x1800302f; 0x0800302f; 0x0000302f; 0x2000302f; 0x6000302f // LR SC SWAP ADD XOR AND
+      0x4000302f; 0x8000302f; 0xA000302f; 0xC000302f; 0xE000302f ]           // OR MIN MAX MINU MAXU
+    |> List.iter (fun w -> DA64.verbosityMessage w (DA64.Decode w) m64)
+    DA64.verbosityMessage 0 DA64.None m64
+
+// =====================================================================
+// DecodeI: false-branches of the shift / FENCE / SYSTEM when-guards.
+// =====================================================================
+
+[<Fact>]
+let ``I decode: SRAI guard false branches`` () =
+    // funct3=101, funct6=0b010000, shamt[5]=1 on RV32 -> shamt_ok=false -> None
+    Assert.Equal(DI.None, DI.Decode m32 0x42005013)
+    // funct3=101 with funct6 neither 0 nor 0b010000 -> guard cond1 false -> None
+    Assert.Equal(DI.None, DI.Decode m32 0x80005013)
+
+[<Fact>]
+let ``I decode: FENCE/SYSTEM guard false branches`` () =
+    // FENCE opcode (0b0001111) with rd / rs1 / funct3 != 0 -> None
+    Assert.Equal(DI.None, DI.Decode m32 0x0000008F)  // rd=1
+    Assert.Equal(DI.None, DI.Decode m32 0x0000800F)  // rs1=1
+    Assert.Equal(DI.None, DI.Decode m32 0x0000100F)  // funct3=1
+    // SYSTEM opcode (0b1110011) with rd / rs1 / funct3 != 0, or imm not 0/1 -> None
+    Assert.Equal(DI.None, DI.Decode m32 0x000000F3)  // rd=1
+    Assert.Equal(DI.None, DI.Decode m32 0x00008073)  // rs1=1
+    Assert.Equal(DI.None, DI.Decode m32 0x00001073)  // funct3=1
+    Assert.Equal(DI.None, DI.Decode m32 0x00200073)  // imm12=2 (neither ECALL nor EBREAK)

--- a/Tests/unit/cli.fs
+++ b/Tests/unit/cli.fs
@@ -119,3 +119,28 @@ let ``long-key-only option with value advances past both tokens`` () =
     let opt = { CliOptions.Default with LongKey = Some "name"; Value = Some "N" }
     let (_, leftover) = fetchArgs [| "--name"; "bob" |] opt AppConfig.Default
     Assert.Equal<string[]>([||], leftover)
+
+// Exercise every fetchArgs/parseCli arm and guard combination for branch coverage.
+[<Fact>]
+let ``parser exercises all fetchArgs and parseCli arms`` () =
+    let filesOpt = { CliOptions.Default with Value = Some "F"; Multiple = true }
+    let keyMul   = { CliOptions.Default with Key = Some "f"; Multiple = true }
+    let aOpt     = { CliOptions.Default with Key = Some "A"; Value = Some "ARCH" }
+    // Multiple value-option: several values (recurse), single (base), and empty argv
+    fetchArgs [| "a"; "b"; "c" |] filesOpt AppConfig.Default |> ignore
+    fetchArgs [| "a" |] filesOpt AppConfig.Default |> ignore
+    fetchArgs [||] filesOpt AppConfig.Default |> ignore
+    // Multiple key-option: trailing match (recurse) and non-match (inner NotFound->Result)
+    fetchArgs [| "-f"; "-f" |] keyMul AppConfig.Default |> ignore
+    fetchArgs [| "-f"; "z" |] keyMul AppConfig.Default |> ignore
+    // Non-multiple option: leftover (_ with len-resIndex>0) and none (_ with =0)
+    fetchArgs [| "-A"; "rv32i"; "x"; "y" |] aOpt AppConfig.Default |> ignore
+    fetchArgs [| "-A"; "rv32i" |] aOpt AppConfig.Default |> ignore
+    // NotFound with following args (recurse) and as the only arg
+    fetchArgs [| "zzz"; "-A"; "rv32i" |] aOpt AppConfig.Default |> ignore
+    fetchArgs [| "zzz" |] aOpt AppConfig.Default |> ignore
+    // parseCli: single option (opts.Length=1), full chain with trailing files, empty argv
+    parseCli [| "-A"; "rv32i" |] [| aOpt |] AppConfig.Default |> ignore
+    parseCli [| "-A"; "rv32i"; "f1"; "f2" |] InitCLI AppConfig.Default |> ignore
+    parseCli [||] InitCLI AppConfig.Default |> ignore
+    Assert.True true

--- a/Tests/unit/units.fs
+++ b/Tests/unit/units.fs
@@ -44,6 +44,12 @@ let ``Int64 bit helpers`` () =
     x.display
 
 [<Fact>]
+let ``combineBytes over empty, single and multi-byte arrays`` () =
+    Assert.Equal(0L, combineBytes [||])                       // empty range branch
+    Assert.Equal(0xABL, combineBytes [| 0xABuy |])            // single byte
+    Assert.Equal(0xCDABL, combineBytes [| 0xABuy; 0xCDuy |])  // little-endian combine
+
+[<Fact>]
 let ``load helpers return None on unmapped memory`` () =
     let mem : Map<int64, byte> = Map.empty
     Assert.True((loadByte mem 0L).IsNone)

--- a/Tests/unit/units.fs
+++ b/Tests/unit/units.fs
@@ -16,6 +16,14 @@ open ISA.RISCV.Utils.Bits
 [<InlineData("rv64ia")>]
 [<InlineData("rv32ima")>]
 [<InlineData("rv64ima")>]
+[<InlineData("rv32ic")>]
+[<InlineData("rv64ic")>]
+[<InlineData("rv32imc")>]
+[<InlineData("rv64imc")>]
+[<InlineData("rv32iac")>]
+[<InlineData("rv64iac")>]
+[<InlineData("rv32imac")>]
+[<InlineData("rv64imac")>]
 let ``Architecture.fromString parses every valid arch`` (s : string) =
     Assert.True((Architecture.fromString s).IsSome)
 

--- a/risc-v.fsproj
+++ b/risc-v.fsproj
@@ -5,10 +5,10 @@
         <TargetFramework>net10.0</TargetFramework>
         <RootNamespace>ISA.RISCV</RootNamespace>
         <PackageId>ISA.RISC-V</PackageId>
-        <Version>0.5.0</Version>
+        <Version>0.6.0</Version>
         <Title>RISC-V CPU</Title>
         <Authors>mrLSD (Evgeny Ukhanov)</Authors>
-        <Description>RISC-V CPU formal implementation that implement basic RISC-V ISA: rv32i
+        <Description>RISC-V CPU formal implementation that implement basic RISC-V ISA: rv32imac
 
 Additionally it's possible to operate with CLI, reading ELF files and set verbosity output.</Description>
         <Copyright>Evgeny Ukhanov</Copyright>
@@ -19,7 +19,7 @@ Additionally it's possible to operate with CLI, reading ELF files and set verbos
 
     <ItemGroup>
         <PackageReference Include="ELFSharp" Version="2.17.3" />
-        <PackageReference Update="FSharp.Core" Version="10.0.107" />
+        <PackageReference Update="FSharp.Core" Version="10.0.108" />
     </ItemGroup>
 
     <ItemGroup>

--- a/risc-v.fsproj
+++ b/risc-v.fsproj
@@ -32,12 +32,14 @@ Additionally it's possible to operate with CLI, reading ELF files and set verbos
         <Compile Include="DecodeM64.fs" />
         <Compile Include="DecodeA.fs" />
         <Compile Include="DecodeA64.fs" />
+        <Compile Include="DecodeC.fs" />
         <Compile Include="ExecuteI.fs" />
         <Compile Include="ExecuteI64.fs" />
         <Compile Include="ExecuteM.fs" />
         <Compile Include="ExecuteM64.fs" />
         <Compile Include="ExecuteA.fs" />
         <Compile Include="ExecuteA64.fs" />
+        <Compile Include="ExecuteC.fs" />
         <Compile Include="Decoder.fs" />
         <Compile Include="CLI.fs" />
         <Compile Include="Run.fs" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full support for RISC-V Compressed (C) 16-bit instructions and new architecture variants combining C, M, and A (rv32*/rv64*).
  * Automatic instruction-length detection and proper PC advancement for mixed 16/32-bit code.

* **Refactor**
  * Alignment checks and instruction-length handling unified for all architectures; machine state updated to track instruction length.

* **Tests**
  * Comprehensive compressed-instruction decode/execute tests and extended architecture/unit coverage.

* **Chores**
  * Documentation and changelog updated; CLI help expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->